### PR TITLE
WIP : Simplify unpivoted QR of A[:, panel]

### DIFF
--- a/CMake/build_options.cmake
+++ b/CMake/build_options.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_SHARED_LIBS OFF "Configure to build shared or static libraries")

--- a/include/hqrrp.h
+++ b/include/hqrrp.h
@@ -9,10 +9,10 @@
 
 namespace HQRRP {
 
-void dgeqpr(int64_t m, int64_t n, double *A, int64_t lda, int64_t *jpvt, double *tau);
+void dgeqpr(int64_t m, int64_t n, double *A, int64_t lda, int64_t *jpvt, double *tau, int64_t panel);
 
 void dgeqpr( int64_t * m, int64_t * n, double * A, int64_t * lda, int64_t * jpvt, double * tau,
-         double * work, int64_t * lwork, int64_t * info );
+         double * work, int64_t * lwork, int64_t * info , int64_t panel );
 
 int64_t hqrrp( int64_t m_A, int64_t n_A, double * buff_A, int64_t ldim_A,
         int64_t * buff_jpvt, double * buff_tau,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,12 +6,24 @@ set(
 add_library(
     hqrrp ${hqrrp_cxx}
 )
+set(
+  hqrrp_cxx_opts
+  -Wall -Wextra
+)
+if (SANITIZE_ADDRESS)
+    list(APPEND hqrrp_cxx_opts -fsanitize=address)
+    target_link_options(hqrrp INTERFACE -fsanitize=address)
+endif()
 
 target_include_directories(
     hqrrp PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${Random123_DIR}>
     $<INSTALL_INTERFACE:include>
+)
+
+target_compile_options(
+  hqrrp PUBLIC ${hqrrp_cxx_opts}
 )
 
 target_link_libraries(hqrrp PUBLIC blaspp lapackpp)

--- a/src/hqrrp.cpp
+++ b/src/hqrrp.cpp
@@ -968,64 +968,27 @@ static int64_t GEQRF_QRmod_WY_unb_var4( int64_t num_stages,
 // Simplification of NoFLA_QRPmod_WY_unb_var4 for the case when pivoting=0.
 // (I don't know what the "var4" signifies in that function name ...).
 //
-  int64_t j, mn_A, m_a21, m_A22, n_A22,
-          n_house_vector, m_rest, * info;
-  int64_t i_neg_one = -1;
-  double  * buff_workspace, diag;
 
   // Some initializations.
-  mn_A    = min( m_A, n_A );
   if( num_stages < 0 )
-    num_stages = mn_A;
+    num_stages = min( m_A, n_A );;
   
+  int64_t info[1];
   double work_query[1];
   int64_t lwork[1];
   lwork[0] = -1;
   _LAPACK_dgeqrf(m_A, n_A, buff_A, ldim_A, buff_t, work_query, lwork, info);
   lwork[0] = max((int64_t) blas::real(work_query[0]), n_A);
-  buff_workspace = ( double * ) malloc( lwork[0] * sizeof( double ) );
+  double *buff_workspace = ( double * ) malloc( lwork[0] * sizeof( double ) );
   _LAPACK_dgeqrf(m_A, n_A, buff_A, ldim_A, buff_t, buff_workspace, lwork, info);
-
-  // // Main Loop.
-  // for( j = 0; j < num_stages; j++ ) {
-  //   m_a21 = m_A - j - 1;
-  //   m_A22 = m_A - j - 1;
-  //   n_A22 = n_A - j - 1;
-
-  //   // Compute tau1 and u21 from alpha11 and a21 such that tau1 and u21
-  //   // determine a Householder transform H such that applying H from the
-  //   // left to the column vector consisting of alpha11 and a21 annihilates
-  //   // the entries in a21 (and updates alpha11).
-  //   n_house_vector = m_a21 + 1;
-  //   lapack::larfg(n_house_vector,
-  //       & buff_A[ j + j * ldim_A ],
-  //       & buff_A[ min( m_A-1, j+1 ) + j * ldim_A ],
-  //       1,
-  //       & buff_t[j]
-  //   );
-
-  //   // / a12t \ =  H / a12t \
-  //   // \ A22  /      \ A22  /
-  //   //
-  //   // where H is formed from tau1 and u21.
-  //   diag = buff_A[ j + j * ldim_A ];
-  //   buff_A[ j + j * ldim_A ] = 1.0;
-  //   m_rest = m_A22 + 1;
-  //   _LAPACK_dlarf( lapack::Side::Left, m_rest, n_A22, 
-  //       & buff_A[ j + j * ldim_A ], 1,
-  //       buff_t[ j ],
-  //       & buff_A[ j + ( j+1 ) * ldim_A ], ldim_A,
-  //       buff_workspace
-  //   );
-  //   buff_A[ j + j * ldim_A ] = diag;
-  // }
 
   // Build T.
   if( build_T ) {
     lapack::larft( lapack::Direction::Forward,
-                  lapack::StoreV::Columnwise,
-                  m_A, num_stages, buff_A, ldim_A, 
-                  buff_t, buff_T, ldim_T);
+                   lapack::StoreV::Columnwise,
+                   m_A, num_stages, buff_A, ldim_A, 
+                   buff_t, buff_T, ldim_T
+    );
   }
   // Remove auxiliary vectors.
   free( buff_workspace );

--- a/test/test_hqrrp.cpp
+++ b/test/test_hqrrp.cpp
@@ -69,7 +69,7 @@ void expand_pqr(
     free(R);
 }
 
-void test_qrcp(int64_t m_A, int64_t n_A, uint64_t a_seed, bool randalg, bool verbose)
+void test_qrcp(int64_t m_A, int64_t n_A, uint64_t a_seed, bool randalg, bool verbose, int64_t panel)
 {
     #define max( a, b ) ( (a) > (b) ? (a) : (b) )
     #define min( a, b ) ( (a) < (b) ? (a) : (b) )
@@ -90,7 +90,7 @@ void test_qrcp(int64_t m_A, int64_t n_A, uint64_t a_seed, bool randalg, bool ver
     
     if (randalg)
     {
-        HQRRP::dgeqpr(m_A, n_A, buff_A, ldim_A, buff_p, buff_tau);
+        HQRRP::dgeqpr(m_A, n_A, buff_A, ldim_A, buff_p, buff_tau, panel);
     }
     else
     {
@@ -117,7 +117,6 @@ void test_qrcp(int64_t m_A, int64_t n_A, uint64_t a_seed, bool randalg, bool ver
         }    
     }
 
-    //free(buff_A);
     delete[] buff_A;
     delete[] buff_A_copy;
     free(buff_Q);
@@ -129,38 +128,38 @@ class TestExpandQRCP : public ::testing::Test
 {
     protected:
 
-    virtual void run(int64_t m_A, int64_t n_A, uint64_t a_seed)
+    virtual void run_panel_piv(int64_t m_A, int64_t n_A, uint64_t a_seed)
     {
-        test_qrcp(m_A, n_A, a_seed, false, false);
+        test_qrcp(m_A, n_A, a_seed, false, false, 1);
     }
 };
 
 TEST_F(TestExpandQRCP, Dim10by3)
 {
-    run(10, 3, 99);
-    run(10, 3, 100);
-    run(10, 3, 101);
+    run_panel_piv(10, 3, 99);
+    run_panel_piv(10, 3, 100);
+    run_panel_piv(10, 3, 101);
 }
 
 TEST_F(TestExpandQRCP, Dim4by4)
 {
-    run(4, 4, 99);
-    run(4, 4, 100);
-    run(4, 4, 101);
+    run_panel_piv(4, 4, 99);
+    run_panel_piv(4, 4, 100);
+    run_panel_piv(4, 4, 101);
 }
 
 TEST_F(TestExpandQRCP, Dim10by10)
 {
-    run(10, 10, 99);
-    run(10, 10, 100);
-    run(10, 10, 101);
+    run_panel_piv(10, 10, 99);
+    run_panel_piv(10, 10, 100);
+    run_panel_piv(10, 10, 101);
 }
 
 TEST_F(TestExpandQRCP, Dim10by100)
 {
-    run(10, 100, 99);
-    run(10, 100, 100);
-    run(10, 100, 101);
+    run_panel_piv(10, 100, 99);
+    run_panel_piv(10, 100, 100);
+    run_panel_piv(10, 100, 101);
 }
 
 
@@ -169,43 +168,83 @@ class TestHQRRP : public ::testing::Test
 {
     protected:
 
-    virtual void run(int64_t m_A, int64_t n_A, uint64_t a_seed)
+    virtual void run_rand_panel_piv(int64_t m_A, int64_t n_A, uint64_t a_seed)
     {
-        test_qrcp(m_A, n_A, a_seed, true, false);
+        test_qrcp(m_A, n_A, a_seed, true, false, 1);
+    }
+
+    virtual void run_rand_no_panel_piv(int64_t m_A, int64_t n_A, uint64_t a_seed)
+    {
+        test_qrcp(m_A, n_A, a_seed, true, false, 0);
     }
 };
 
 TEST_F(TestHQRRP, Dim10by3) 
 {
-   run(10, 3, 99);
-   run(10, 3, 100);
-   run(10, 3, 101);
+   run_rand_panel_piv(10, 3, 99);
+   run_rand_panel_piv(10, 3, 100);
+   run_rand_panel_piv(10, 3, 101);
 }
 
 TEST_F(TestHQRRP, Dim3by10) 
 {
-   run(3, 10, 99);
-   run(3, 10, 100);
-   run(3, 10, 101);
+   run_rand_panel_piv(3, 10, 99);
+   run_rand_panel_piv(3, 10, 100);
+   run_rand_panel_piv(3, 10, 101);
 }
 
 TEST_F(TestHQRRP, Dim10by10)
 {
-    run(10, 10, 99);
-    run(10, 10, 100);
-    run(10, 10, 101);
+    run_rand_panel_piv(10, 10, 99);
+    run_rand_panel_piv(10, 10, 100);
+    run_rand_panel_piv(10, 10, 101);
 }
 
 TEST_F(TestHQRRP, Dim300by100)
 {
-    run(300, 100, 99);
-    run(300, 100, 100);
-    run(300, 100, 101);
+    run_rand_panel_piv(300, 100, 99);
+    run_rand_panel_piv(300, 100, 100);
+    run_rand_panel_piv(300, 100, 101);
 }
 
 TEST_F(TestHQRRP, Dim100by300)
 {
-    run(100, 300, 99);
-    run(100, 300, 100);
-    run(100, 300, 101);
+    run_rand_panel_piv(100, 300, 99);
+    run_rand_panel_piv(100, 300, 100);
+    run_rand_panel_piv(100, 300, 101);
+}
+
+TEST_F(TestHQRRP, Dim10by3_no_panel)
+{
+    run_rand_no_panel_piv(10, 3, 99);
+    run_rand_no_panel_piv(10, 3, 100);
+    run_rand_no_panel_piv(10, 3, 101);
+}
+
+TEST_F(TestHQRRP, Dim3by10_no_panel)
+{
+    run_rand_no_panel_piv(3, 10, 99);
+    run_rand_no_panel_piv(3, 10, 100);
+    run_rand_no_panel_piv(3, 10, 101);
+}
+
+TEST_F(TestHQRRP, Dim10by10_no_panel)
+{
+    run_rand_no_panel_piv(10, 10, 99);
+    run_rand_no_panel_piv(10, 10, 100);
+    run_rand_no_panel_piv(10, 10, 101);
+}
+
+TEST_F(TestHQRRP, Dim300by100_no_panel)
+{
+    run_rand_no_panel_piv(300, 100, 99);
+    run_rand_no_panel_piv(300, 100, 100);
+    run_rand_no_panel_piv(300, 100, 101);
+}
+
+TEST_F(TestHQRRP, Dim100by300_no_panel)
+{
+    run_rand_no_panel_piv(100, 300, 99);
+    run_rand_no_panel_piv(100, 300, 100);
+    run_rand_no_panel_piv(100, 300, 101);
 }


### PR DESCRIPTION
This PR identifies requests for unpivoted QR on A[:, panel] and handles them with a special (but very very simple) function. The new code shows that any routine which is compatible with GEQRF can be dropped into HQRRP and handle the QR of all panels when panel pivoting is off.

This PR also includes incidental changes like adding support for an address sanitizer. The block size and oversampling parameter have been changed from (64, 10) to (16, 16), although this change isn't important and I'll probably change it _again_ before merging.

In order to use CQRRPT inside HQRRP we'd need to modify ``GEQRF_QRmod_WY_unb_var4`` so that instead of using ``_LAPACK_dgeqrf`` you'd use Cholesky QR with Householder restoration. We'd also need to make sure we only pass in the _preconditioned_ panel into ``GEQRF_QRmod_WY_unb_var4``.